### PR TITLE
Update function install_prerequisites, add libevent-dev. Fixes 'configure: error: libevent not found'

### DIFF
--- a/raspnode.sh
+++ b/raspnode.sh
@@ -234,7 +234,7 @@ function build_lndconf {
 # INSTALL PREREQUISITES#######################################################################
 function install_prerequisites {
     writeyellow 'Installing prerequisites'
-    sudo apt-get install -y autoconf automake build-essential git libtool libgmp-dev libsqlite3-dev python python3 net-tools libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-program-options-dev libboost-test-dev libboost-thread-dev libssl-dev tmux
+    sudo apt-get install -y autoconf automake build-essential git libtool libevent-dev libgmp-dev libsqlite3-dev python python3 net-tools libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-program-options-dev libboost-test-dev libboost-thread-dev libssl-dev tmux
     writegreen 'Prerequisites installed'
 }
 # MAIN - MAIN - MAIN - MAIN - MAIN - MAIN - MAIN - MAIN - MAIN - MAIN - MAIN - MAIN - MAIN ###


### PR DESCRIPTION
On Raspberry Pi 3B:

<img width="682" alt="ss_libevent-dev" src="https://user-images.githubusercontent.com/419920/37796557-de1f8732-2e17-11e8-82fb-4f0737d727d7.png">
